### PR TITLE
Avoid passing a generator to TfidfVectorizer; Fixes #9

### DIFF
--- a/asari/preprocess.py
+++ b/asari/preprocess.py
@@ -3,4 +3,4 @@ t = Tokenizer()
 
 
 def tokenize(text):
-    return t.tokenize(text, wakati=True)
+    return list(t.tokenize(text, wakati=True))


### PR DESCRIPTION
From Janome v0.4.0, it always return a generator for the result of tokenization (https://mocobeta.github.io/janome/#v0-3-1-v0-3-10). As TfidfVectorizer doesn't work for generators, we should eagerly convert the generator into list.